### PR TITLE
Fix unexpected NullPointerException in CI (cgroup v2 / JMX related)

### DIFF
--- a/docker-action/entrypoint.sh
+++ b/docker-action/entrypoint.sh
@@ -29,7 +29,7 @@ getFileListInDir () (
 )
 
 GOBRA_JAR="/gobra/gobra.jar"
-JAVA_ARGS="-Xss$INPUT_JAVAXSS -Xmx$INPUT_JAVAXMX -jar $GOBRA_JAR"
+JAVA_ARGS="-Xss$INPUT_JAVAXSS -Xmx$INPUT_JAVAXMX -XX:-UseContainerSupport -Dcom.sun.management.jmxremote=false -jar $GOBRA_JAR"
 GOBRA_ARGS="--backend $INPUT_VIPERBACKEND --chop $INPUT_CHOP"
 
 if [[ $INPUT_PROJECTLOCATION ]]; then


### PR DESCRIPTION
Description and fix generated by chatGPT:

## Description

A GitHub Action that has been stable for a long time recently started failing without any changes to our codebase. The failure occurs during Gobra verification when running inside a Docker container in CI.

The exception appears to originate from the JDK’s cgroup v2/container metrics handling and is triggered during JMX initialization via Apache Commons Pool.

## Observed Behavior

Every run fails with:
```
java.lang.NullPointerException
	at java.base/jdk.internal.platform.cgroupv2.CgroupV2Subsystem.getInstance
	at java.base/jdk.internal.platform.CgroupSubsystemFactory.create
	at java.base/jdk.internal.platform.CgroupMetrics.getInstance
	at java.base/jdk.internal.platform.SystemMetrics.instance
	at java.base/jdk.internal.platform.Metrics.systemMetrics
	at java.base/jdk.internal.platform.Container.metrics
	at jdk.management/com.sun.management.internal.OperatingSystemImpl.<init>
	at java.management/java.lang.management.ManagementFactory.getPlatformMBeanServer
	at org.apache.commons.pool2.impl.BaseGenericObjectPool.jmxRegister
	...
```
The exception occurs during Silicon backend initialization.

## Expected Behavior

Verification should complete normally, as it did previously in the same CI configuration.

## Environment

Runs in GitHub Actions (Docker container)

## Additional Observations

The stack trace suggests the failure happens during:
- JMX initialization
- Container metrics retrieval
- cgroup v2 subsystem access

This may be related to:
- Recent updates to GitHub runner images
- Changes in default JDK container support behavior
- cgroup v2 environment changes

## Workaround

Adding the following JVM flags appears to prevent the crash:
```
-XX:-UseContainerSupport
-Dcom.sun.management.jmxremote=false
```

This disables container awareness and JMX registration.