### PR TITLE
refactor: Fix deprecated gh actions syntax

### DIFF
--- a/docker-action/entrypoint.sh
+++ b/docker-action/entrypoint.sh
@@ -183,7 +183,7 @@ fi
 
 TIME_PASSED=$[ $SECONDS-$START_TIME ]
 
-echo "::set-output name=time::$TIME_PASSED"
+echo "time=$TIME_PASSED" >> $GITHUB_OUTPUT
 
 echo "[DEBUG] Contents of /tmp/:" > $DEBUG_OUT
 ls -la /tmp/ > $DEBUG_OUT


### PR DESCRIPTION
This fixes a deprecation [warning in the CI](https://github.com/scionproto/scion/actions/runs/22086480308/job/63822251455?pr=4886) of github.com/scionproto/scion:

<img width="560" height="153" alt="Screenshot 2026-02-17 at 12 07 24" src="https://github.com/user-attachments/assets/517d4794-2132-4324-bb9c-ecac0740aba0" />

See https://github.blog/changelog/2022-10-10-github-actions-deprecating-save-state-and-set-output-commands/